### PR TITLE
refactor: unify naming and add dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Tool Execution Planning & Cancellation System
+# Tool Execution Planning & Compensation System
 
-A Model Context Protocol (MCP) server for managing tool call sequences with contextual dependencies. This system helps AI coordinate multiple tool calls and handle failures through manual cancellation actions.
+A Model Context Protocol (MCP) server for managing tool call sequences with contextual dependencies. This system helps AI coordinate multiple tool calls and handle failures through manual compensation actions.
 
 ## What This System Actually Does
 
 **This is NOT the MSA Saga pattern for distributed transactions.** Instead, this system manages "loose contextual connections" between tool calls. For example:
 
-- If a "travel booking" tool call fails, a "hat purchase" tool call that is contextually linked should also be cancelled
-- If a "database migration" fails, related "backup creation" and "notification sending" should be cancelled
-- The AI is responsible for detecting failures and manually invoking cancellation tools
+- If a "travel booking" tool call fails, a "hat purchase" tool call that is contextually linked should also be compensated
+- If a "database migration" fails, related "backup creation" and "notification sending" should be compensated
+- The AI is responsible for detecting failures and manually invoking compensation tools
 
 ## Core Concept: Execution Support, Not Execution Guarantee
 
 This system provides **execution support** for complex tool call sequences, not automatic execution guarantees. The AI must:
 
-- Design robust plans with proper cancellation strategies
+- Design robust plans with proper compensation strategies
 - Monitor execution status continuously
-- Handle failures manually by calling cancellation tools
+- Handle failures manually by calling compensation tools
 - Consider contextual dependencies between tool calls
 
 ## Available Tools
@@ -28,7 +28,7 @@ This system provides **execution support** for complex tool call sequences, not 
 ### Execution Control
 - **`status`** - Check execution status and progress
 - **`control`** - Pause, resume, or cancel executions
-- **`record_compensation`** - Log cancellation actions for audit trails
+  - **`record_compensation`** - Log compensation actions for audit trails
 
 ## Usage Examples
 
@@ -42,20 +42,21 @@ This system provides **execution support** for complex tool call sequences, not 
       {
         "id": "book_hotel",
         "name": "Book Hotel",
-        "tool": "book_hotel",
+        "tool_name": "book_hotel",
         "parameters": {"destination": "Paris", "dates": "2024-07-15 to 2024-07-22"},
-        "cancellation": {
-          "tool": "cancel_hotel",
+        "compensation": {
+          "tool_name": "cancel_hotel",
           "parameters": {"booking_id": "{{hotel_booking_id}}"}
         }
       },
       {
         "id": "book_car",
         "name": "Book Rental Car",
-        "tool": "book_car",
+        "tool_name": "book_car",
         "parameters": {"pickup_location": "Paris Airport", "dates": "2024-07-15 to 2024-07-22"},
-        "cancellation": {
-          "tool": "cancel_car",
+        "depends_on": ["book_hotel"],
+        "compensation": {
+          "tool_name": "cancel_car",
           "parameters": {"booking_id": "{{car_booking_id}}"}
         }
       }
@@ -92,7 +93,7 @@ This system provides **execution support** for complex tool call sequences, not 
 }
 ```
 
-### 5. Record Cancellation
+### 5. Record Compensation
 ```json
 {
   "execution_id": "exec_xyz789",
@@ -112,7 +113,7 @@ src/
 │   ├── ExecutePlanTool.ts   # Plan execution
 │   ├── StatusTool.ts        # Status monitoring
 │   ├── ControlTool.ts       # Execution control
-│   └── RecordCompensationTool.ts # Cancellation logging
+  │   └── RecordCompensationTool.ts # Compensation logging
 ├── prompts/                  # AI guidance and templates
 │   └── ToolExecutionPlanningPrompt.ts
 ├── resources/                # Documentation and examples
@@ -161,9 +162,9 @@ Add this to your MCP client configuration:
 ## Key Features
 
 - **Contextual Dependencies**: Manage relationships between tool calls
-- **Manual Cancellation**: AI-driven failure handling and rollback
+- **Manual Compensation**: AI-driven failure handling and rollback
 - **Execution Monitoring**: Real-time status tracking and control
-- **Audit Trail**: Comprehensive logging of all actions and cancellations
+- **Audit Trail**: Comprehensive logging of all actions and compensations
 - **Flexible Planning**: Support for complex, multi-step workflows
 
 ## Important Notes
@@ -171,7 +172,7 @@ Add this to your MCP client configuration:
 1. **This is NOT the MSA Saga pattern** - No automatic rollback or distributed transaction guarantees
 2. **AI Responsibility** - The AI must monitor execution and handle failures manually
 3. **Contextual Awareness** - Always consider how tool failures affect related operations
-4. **Cancellation First** - Design plans with cancellation strategies from the beginning
+4. **Compensation First** - Design plans with compensation strategies from the beginning
 
 ## Development Status
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
-# Tool Execution Planning & Cancellation System - Development TODO
+# Tool Execution Planning & Compensation System - Development TODO
 
 ## Project Overview
 
-This system is designed to help AI manage complex tool call sequences with contextual dependencies. It provides execution support for coordinating multiple tool calls and handling failures through manual cancellation actions.
+This system is designed to help AI manage complex tool call sequences with contextual dependencies. It provides execution support for coordinating multiple tool calls and handling failures through manual compensation actions.
 
 ## CRITICAL: Current System Limitations
 
@@ -11,8 +11,8 @@ This system is designed to help AI manage complex tool call sequences with conte
 ### What This System Actually Does
 - Helps AI plan and execute sequences of tool calls
 - Tracks execution progress and status
-- Provides tools for manual cancellation when failures occur
-- Records cancellation actions for audit trails
+- Provides tools for manual compensation when failures occur
+- Records compensation actions for audit trails
 - Manages contextual dependencies between related operations
 
 ### What This System Does NOT Do
@@ -23,11 +23,11 @@ This system is designed to help AI manage complex tool call sequences with conte
 
 ## AI Responsibilities
 
-1. **Plan Design**: Create robust plans with cancellation strategies
+1. **Plan Design**: Create robust plans with compensation strategies
 2. **Execution Monitoring**: Continuously monitor execution status
-3. **Failure Handling**: Detect failures and manually invoke cancellation tools
+3. **Failure Handling**: Detect failures and manually invoke compensation tools
 4. **Contextual Awareness**: Consider how tool failures affect related operations
-5. **Manual Cancellation**: Execute cancellation actions when needed
+5. **Manual Compensation**: Execute compensation actions when needed
 
 ## Completed Features
 
@@ -50,7 +50,7 @@ This system is designed to help AI manage complex tool call sequences with conte
 - 📋 Parallel tool execution
 - 📋 Enhanced monitoring and logging
 - 📋 Integration with external tool systems
-- 📋 Advanced cancellation strategies
+- 📋 Advanced compensation strategies
 
 ## Current Architecture
 
@@ -67,7 +67,7 @@ This system is designed to help AI manage complex tool call sequences with conte
 4. System tracks execution progress
 5. AI monitors status using `status` tool
 6. AI controls execution using `control` tool
-7. AI records cancellations using `record_compensation`
+7. AI records compensations using `record_compensation`
 
 ## Immediate Next Steps
 
@@ -88,10 +88,10 @@ This system is designed to help AI manage complex tool call sequences with conte
 ## Critical Warnings for AI Users
 
 1. **This is NOT the MSA Saga pattern** - No automatic rollback or distributed transaction guarantees
-2. **Manual Cancellation Required** - You must explicitly invoke cancellation tools when failures occur
+2. **Manual Compensation Required** - You must explicitly invoke compensation tools when failures occur
 3. **Contextual Dependencies** - Always consider how tool failures affect related operations
 4. **Execution Monitoring** - Continuously monitor execution status to detect failures early
-5. **Cancellation-First Design** - Design plans with cancellation strategies from the beginning
+5. **Compensation-First Design** - Design plans with compensation strategies from the beginning
 
 ## Technical Notes
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tool-execution-planner",
   "version": "0.0.1",
   "type": "module",
-  "description": "Tool Execution Planning & Cancellation System - MCP server for managing tool call sequences with contextual dependencies",
+  "description": "Tool Execution Planning & Compensation System - MCP server for managing tool call sequences with contextual dependencies",
   "main": "dist/index.js",
   "bin": {
     "tool-execution-planner": "./dist/index.js"
@@ -30,7 +30,7 @@
     "mcp",
     "tool-execution",
     "planning",
-    "cancellation",
+    "compensation",
     "contextual-dependencies"
   ],
   "author": "Your Name",

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ try {
     (server as any).addResource(ToolExecutionExamplesResource);
   }
 } catch (error) {
-  // Silent registration - MCP Framework will handle errors
+  console.error("Failed to register components:", error);
 }
 
 // 서버 시작

--- a/src/prompts/SagaPlanningPrompt.ts
+++ b/src/prompts/SagaPlanningPrompt.ts
@@ -32,8 +32,8 @@ class ToolExecutionPlanningPrompt extends MCPPrompt<ToolExecutionPlanningInput> 
   async generateMessages({ goal, complexity = "medium", domain = "general" }: ToolExecutionPlanningInput) {
     const complexityGuidance: Record<string, string> = {
       simple: "For simple operations, focus on 2-3 sequential tool calls with basic error handling.",
-      medium: "For medium complexity, consider tool call sequences and include cancellation logic.",
-      complex: "For complex operations, break down into logical phases and ensure comprehensive cancellation strategies."
+      medium: "For medium complexity, consider tool call sequences and include compensation logic.",
+      complex: "For complex operations, break down into logical phases and ensure comprehensive compensation strategies."
     };
 
     return [
@@ -41,22 +41,22 @@ class ToolExecutionPlanningPrompt extends MCPPrompt<ToolExecutionPlanningInput> 
         role: "system",
         content: {
           type: "text",
-          text: `You are a tool execution planning expert. Your role is to help create robust plans for executing sequences of tool calls that can handle failures gracefully through cancellation actions.
+          text: `You are a tool execution planning expert. Your role is to help create robust plans for executing sequences of tool calls that can handle failures gracefully through compensation actions.
 
 IMPORTANT: This system provides execution SUPPORT, not execution GUARANTEES. You (the AI) are responsible for:
-- Designing resilient plans with cancellation actions for each tool call
+- Designing resilient plans with compensation actions for each tool call
 - Detecting failures and deciding when to cancel the entire plan
-- Explicitly invoking cancellation tools
+- Explicitly invoking compensation tools
 - Monitoring execution status and handling errors
 - Ensuring data consistency through proper planning
 
 The system does NOT automatically:
 - Retry failed tool calls
-- Execute cancellation actions
+- Execute compensation actions
 - Handle rollbacks
 - Guarantee successful completion
 
-NOTE: This is NOT the MSA Saga pattern. This is a tool execution planning and cancellation system for managing contextual dependencies between tool calls.`
+NOTE: This is NOT the MSA Saga pattern. This is a tool execution planning and compensation system for managing contextual dependencies between tool calls.`
         }
       },
       {
@@ -74,19 +74,19 @@ ${complexityGuidance[complexity]}
 Please provide:
 1. A structured plan with clear tool call sequences
 2. Dependencies between tool calls (if any) - Note: Currently executed sequentially
-3. Cancellation actions for each tool call - YOU must execute these manually
+3. Compensation actions for each tool call - YOU must execute these manually
 4. Risk assessment and failure points
 5. JSON format for the plan structure
 6. Your monitoring and failure handling strategy
 
 CRITICAL REMINDERS:
 - This system provides tools and infrastructure for managing tool call sequences
-- Always include cancellation actions for every tool call
+- Always include compensation actions for every tool call
 - Plan for manual intervention when tool calls fail
 - Monitor execution status continuously
-- Be prepared to call cancellation tools explicitly
+- Be prepared to call compensation tools explicitly
 - This is NOT the MSA Saga pattern - it's a tool execution planning system
-- Focus on contextual dependencies: if one tool call fails, what other tool calls need to be cancelled?
+- Focus on contextual dependencies: if one tool call fails, what other tool calls need to be compensated?
 
 Remember: This system provides execution SUPPORT, not execution GUARANTEES. You must design robust plans and handle failures explicitly.`
         }

--- a/src/resources/SagaDocumentationResource.ts
+++ b/src/resources/SagaDocumentationResource.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 class ToolExecutionDocumentationResource extends MCPResource {
   uri = "resource://tool-execution/documentation";
   name = "Tool Execution Planning Documentation";
-  description = "Comprehensive documentation for tool execution planning and cancellation system";
+  description = "Comprehensive documentation for tool execution planning and compensation system";
   mimeType = "text/markdown";
 
   async read() {
@@ -18,7 +18,7 @@ class ToolExecutionDocumentationResource extends MCPResource {
         fs.readFile(todoPath, "utf-8").catch(() => "# TODO\n\nTask list not available")
       ]);
 
-      const combinedContent = `# Tool Execution Planning & Cancellation System Documentation
+      const combinedContent = `# Tool Execution Planning & Compensation System Documentation
 
 ## Overview
 ${readmeContent.split("## ")[1] || "Tool execution planning implementation for MCP"}
@@ -33,19 +33,19 @@ ${todoContent.split("## ")[1] || "Status information not available"}
 - **Plan Management**: Save, load, and organize tool execution plans
 - **Basic Execution Control**: Start, pause, resume, cancel tool execution plans
 - **Status Monitoring**: Track execution progress and tool call results
-- **Cancellation Recording**: Log cancellation actions (but NOT execute them)
+- **Compensation Recording**: Log compensation actions (but NOT execute them)
 
 ### What This System is NOT:
 - **MSA Saga Pattern**: This is NOT the microservices saga pattern
 - **Execution Guarantee System**: Does NOT automatically ensure successful completion
-- **Auto-Recovery System**: Does NOT automatically handle failures or cancellations
+- **Auto-Recovery System**: Does NOT automatically handle failures or compensations
 - **Parallel Executor**: Tools are called sequentially (no parallel execution yet)
 - **Intelligent Retry System**: Basic retry only, no smart failure handling
 
 ## Key Concepts
 - **Execution Support, Not Execution Guarantee**: The system provides tools and infrastructure for robust tool execution planning, but AI must design resilient plans
-- **Cancellation-First Design**: Every tool call should have a corresponding cancellation action
-- **Failure Handling**: AI must explicitly handle failures and invoke cancellation tools
+- **Compensation-First Design**: Every tool call should have a corresponding compensation action
+- **Failure Handling**: AI must explicitly handle failures and invoke compensation tools
 - **Sequential Execution**: Tools are called one after another (parallel execution planned for future)
 - **Contextual Dependencies**: Manage relationships between tool calls (e.g., hotel booking failure affects car rental and activity bookings)
 
@@ -53,28 +53,28 @@ ${todoContent.split("## ")[1] || "Status information not available"}
 
 ### 1. Plan Design
 - Create comprehensive plans with clear tool call sequences
-- Define cancellation actions for each tool call
-- Consider failure scenarios and cancellation strategies
+- Define compensation actions for each tool call
+- Consider failure scenarios and compensation strategies
 - Plan for manual intervention when tool calls fail
 - Identify contextual dependencies between tool calls
 
 ### 2. Failure Handling
 - Monitor execution status continuously
 - Detect when tool calls fail or timeout
-- Explicitly call cancellation tools when needed
+- Explicitly call compensation tools when needed
 - Decide when to pause, resume, or cancel
 - Understand the ripple effects of failures
 
-### 3. Cancellation Management
-- Record cancellation actions using record_compensation
-- Execute cancellation operations manually
+### 3. Compensation Management
+- Record compensation actions using record_compensation
+- Execute compensation operations manually
 - Ensure data consistency through proper planning
-- Document what was cancelled and why
-- Handle contextual dependencies (if A fails, cancel B and C)
+- Document what was compensated and why
+- Handle contextual dependencies (if A fails, compensate B and C)
 
 ## Usage Guidelines
 1. Always design plans with failure scenarios in mind
-2. Include cancellation actions for every tool call
+2. Include compensation actions for every tool call
 3. Test your plans with the available tools
 4. Monitor execution status and handle failures gracefully
 5. Be prepared to manually intervene when failures occur
@@ -82,14 +82,14 @@ ${todoContent.split("## ")[1] || "Status information not available"}
 
 ## Current Limitations
 - **Sequential Execution**: Tools are called one after another (no parallel execution yet)
-- **Auto-cancellation**: Not implemented - AI must handle manually
+- **Auto-compensation**: Not implemented - AI must handle manually
 - **Retry Logic**: Basic retry in tool coordinator only
 - **Mock Tools**: Tools are simulated, not real external services
 
 ## What AI Should Know
 1. **This is a tool execution planning and management system**
 2. **You design the plans and handle failures**
-3. **Cancellation must be explicitly invoked**
+3. **Compensation must be explicitly invoked**
 4. **Monitor execution status continuously**
 5. **Use the provided tools to manage your tool call sequences**
 6. **Success depends on your careful planning and monitoring**

--- a/src/tools/ControlTool.ts
+++ b/src/tools/ControlTool.ts
@@ -36,7 +36,7 @@ Note: This is a tool execution planning system, not the MSA Saga pattern.
 - Execution is paused but not rolled back
 - You can resume from the current state
 - Monitor the execution to understand why it was paused
-- Consider if cancellation is needed instead of just pausing`;
+- Consider if compensation is needed instead of just pausing`;
           break;
           
         case "resume":
@@ -56,8 +56,8 @@ Note: This is a tool execution planning system, not the MSA Saga pattern.
 
 Note: This is a tool execution planning system, not the MSA Saga pattern.
 - Execution is stopped but not automatically rolled back
-- You must manually execute cancellation actions for completed steps
-- Use record_compensation to log what was cancelled
+- You must manually execute compensation actions for completed steps
+- Use record_compensation to log what was compensated
 - Consider the impact on related operations`;
           break;
       }

--- a/src/tools/RecordCompensationTool.ts
+++ b/src/tools/RecordCompensationTool.ts
@@ -9,28 +9,28 @@ class RecordCompensationTool extends MCPTool<{
   details?: Record<string, any>;
 }> {
   name = "record_compensation";
-  description = "Record a cancellation action that was performed manually";
+  description = "Record a compensation action that was performed manually";
 
   schema = {
     execution_id: {
       type: z.string(),
-      description: "ID of the execution where the cancellation occurred"
+      description: "ID of the execution where the compensation occurred",
     },
     step_id: {
       type: z.string(),
-      description: "ID of the step that was cancelled"
+      description: "ID of the step that was compensated",
     },
     reason: {
       type: z.string(),
-      description: "Reason why the cancellation was necessary"
+      description: "Reason why the compensation was necessary",
     },
     action_taken: {
       type: z.string(),
-      description: "Description of what cancellation action was performed"
+      description: "Description of what compensation action was performed",
     },
     details: {
       type: z.record(z.any()).optional(),
-      description: "Additional details about the cancellation"
+      description: "Additional details about the compensation",
     }
   };
 
@@ -38,8 +38,8 @@ class RecordCompensationTool extends MCPTool<{
     try {
       const timestamp = new Date().toISOString();
       const compensationId = `comp_${Date.now().toString(36)}`;
-      
-      const resultText = `Cancellation action recorded successfully!
+
+      const resultText = `Compensation action recorded successfully!
 
 Compensation ID: ${compensationId}
 Execution ID: ${input.execution_id}
@@ -50,13 +50,13 @@ Timestamp: ${timestamp}
 ${input.details ? `Details: ${JSON.stringify(input.details, null, 2)}` : ''}
 
 Note: This is a tool execution planning system, not the MSA Saga pattern.
-- Cancellation actions are recorded but not automatically executed
-- You must manually invoke cancellation tools when failures occur
-- This tool helps track what was cancelled and why
+- Compensation actions are recorded but not automatically executed
+- You must manually invoke compensation tools when failures occur
+- This tool helps track what was compensated and why
 - Use this information for audit trails and debugging
 
-Remember: Always consider contextual dependencies when cancelling operations.
-If one tool call fails, related tool calls may also need to be cancelled.`;
+Remember: Always consider contextual dependencies when compensating operations.
+If one tool call fails, related tool calls may also need to be compensated.`;
 
       return {
         content: [{

--- a/src/tools/StatusTool.ts
+++ b/src/tools/StatusTool.ts
@@ -53,8 +53,8 @@ ${mockStatus.steps.map((step: any, index: number) =>
 
       statusText += `\n\nNote: This is a tool execution planning system, not the MSA Saga pattern.
 - Monitor status continuously to detect failures
-- Handle failures manually by calling cancellation tools
-- Each step has defined cancellation actions for rollback`;
+- Handle failures manually by calling compensation tools
+- Each step has defined compensation actions for rollback`;
 
       return {
         content: [{


### PR DESCRIPTION
## Summary
- align plan schema with core types using `tool_name`, `compensation`, and optional `depends_on`
- adopt compensation terminology across docs, prompts, and tools with structured JSON responses
- log registration errors during server startup for easier debugging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'better-sqlite3' and other type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68af78cf0e64832b9cfc7bb329f43210